### PR TITLE
config fs list, improve hard quota

### DIFF
--- a/quota-export.py
+++ b/quota-export.py
@@ -16,7 +16,7 @@ from wekalib import signal_handling, WekaCluster
 
 from collector import Collector
 
-VERSION = "1.0.0"
+VERSION = "2025-04-29"
 
 # set the root log
 log = logging.getLogger()
@@ -60,6 +60,9 @@ def prom_client(config):
 
     if 'force_https' not in config['cluster']:  # allow defaults for these
         config['cluster']['force_https'] = False
+
+    if 'filesystems' not in config['cluster']:
+        config['cluster']['filesystems'] = None
 
     if 'verify_cert' not in config['cluster']:
         config['cluster']['verify_cert'] = True

--- a/quota-export.yml
+++ b/quota-export.yml
@@ -9,8 +9,10 @@ exporter:
 cluster:
   auth_token_file: auth-token.json
   hosts:
-    - vweka01
-    - vweka02
-    - vweka03
+    - weka65
+    - weka66
+    - weka67
   force_https: False   # only 3.10+ clusters support https
   verify_cert: False  # default cert cannot be verified
+  filesystems:
+    - six


### PR DESCRIPTION
Add filesystems: to cluster config - a list of filesystems to look at; all others are ignored.  If None or absent, all filesystems will be used.

Handle hard quotas better when ther is only a hard quota and no soft quota.